### PR TITLE
transfer params:fromName

### DIFF
--- a/lib/sendcloud/deliverer.rb
+++ b/lib/sendcloud/deliverer.rb
@@ -48,7 +48,8 @@ module Sendcloud
         to: rails_message[:to].formatted.join(";"),
         subject: rails_message.subject,
         html: extract_html(rails_message),
-        plain: extract_text(rails_message)
+        plain: extract_text(rails_message),
+        fromName: rails_message['form-name']
       }
 
       [:cc, :bcc].each do |key|

--- a/lib/sendcloud/deliverer.rb
+++ b/lib/sendcloud/deliverer.rb
@@ -49,7 +49,7 @@ module Sendcloud
         subject: rails_message.subject,
         html: extract_html(rails_message),
         plain: extract_text(rails_message),
-        fromName: rails_message['form-name']
+        fromName: rails_message['from-name']
       }
 
       [:cc, :bcc].each do |key|


### PR DESCRIPTION
解析fromName.
起因： from 参数为中文时收到的邮件标题含有双引号